### PR TITLE
Fix `type` in config generated by `koishi init`

### DIFF
--- a/packages/koishi/src/init.ts
+++ b/packages/koishi/src/init.ts
@@ -12,22 +12,22 @@ async function createConfig(options) {
     type: 'select',
     message: 'Connection Type',
     choices: [
-      { title: 'HTTP', value: 'http' },
-      { title: 'WebSocket', value: 'ws' },
+      { title: 'HTTP', value: 'cqhttp:http' },
+      { title: 'WebSocket', value: 'cqhttp:ws' },
     ],
   }, {
     name: 'port',
-    type: (_, data) => data.type === 'http' ? 'number' : null,
+    type: (_, data) => data.type === 'cqhttp:http' ? 'number' : null,
     message: 'Koishi Port',
     initial: 8080,
   }, {
     name: 'server',
-    type: (_, data) => data.type === 'http' ? 'text' : null,
+    type: (_, data) => data.type === 'cqhttp:http' ? 'text' : null,
     message: 'HTTP Server',
     initial: 'http://localhost:5700',
   }, {
     name: 'server',
-    type: (_, data) => data.type === 'ws' ? 'text' : null,
+    type: (_, data) => data.type === 'cqhttp:ws' ? 'text' : null,
     message: 'WebSocket Server',
     initial: 'ws://localhost:6700',
   }, {


### PR DESCRIPTION
#### HTTP `cqhttp:http`
```js
module.exports = {
  type: "cqhttp:http",
  port: 8080,
  server: "http://localhost:5700",
  plugins: [
    "common",
    "schedule"
  ]
}
```
#### WebSocket `cqhttp:ws`
```js
module.exports = {
  type: "cqhttp:ws",
  server: "ws://localhost:6700",
  plugins: [
    "common",
    "schedule"
  ]
}
```