### PR TITLE
test: fix path mapping

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -8,5 +8,8 @@ module.exports = {
     'packages/plugin-eval/tests/*.spec.ts',
     'packages/plugin-teach/tests/*.spec.ts',
   ],
-  require: 'ts-node/register/transpile-only',
+  require: [
+    'ts-node/register/transpile-only',
+    'tsconfig-paths/register',
+  ],
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "rimraf": "^3.0.2",
     "semver": "^7.3.2",
     "ts-node": "^9.0.0",
+    "tsconfig-paths": "^3.9.0",
     "typescript": "^4.0.2"
   }
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "paths": {
       "koishi-plugin-*": ["packages/plugin-*/src"],
       "koishi-adapter-*": ["packages/adapter-*/src"],


### PR DESCRIPTION
According to `tsconfig-paths` documentation,

> Typescript by default mimics the Node.js runtime resolution strategy of modules. But it also allows the use of path mapping which allows arbitrary module paths (that doesn't start with "/" or ".") to be specified and mapped to physical paths in the filesystem. The typescript compiler can resolve these paths from tsconfig so it will compile OK. But if you then try to execute the compiled files with node (or ts-node), it will only look in the node_modules folders all the way up to the root of the filesystem and thus will not find the modules specified by paths in tsconfig.

Adding `tsconfig-paths` solves the unused path-mapping problem.

Btw, `baseUrl` is required when using `paths`.