### PR TITLE
updates for docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   cqhttp:
     image: nanahira/go-cqhttp:latest
     container_name: koishi-go-cqhttp
+    stdin_open: true
     volumes:
       - ./cqhttp:/data
     environment:


### PR DESCRIPTION
1. In Mirai-based CQHttp docker images, `stdin_open` should be added for typing in captcha codes. Use `docker attach` to attach on it and type it in.
2. **TODO** websocket is more recommended as the default interacting method. I have no idea how to configure Koishi to use websocket as default, so not done. Perhaps you may set an `access_token` as default in both containers as well.