### PR TITLE
Update mongo.ts

### DIFF
--- a/packages/plugin-teach/src/database/mongo.ts
+++ b/packages/plugin-teach/src/database/mongo.ts
@@ -106,11 +106,11 @@ extendDatabase<typeof MongoDatabase>('koishi-plugin-mongo', {
 
   async getDialogueStats() {
     const [data, dialogues] = await Promise.all([
-      this.db.collection("dialogue").aggregate([
+      this.db.collection('dialogue').aggregate([
         { $group: { _id: null, questions: { $addToSet: '$question' } } },
         { $project: { questions: { $size: '$questions' } } }
       ]).toArray(),
-      this.db.collection("dialogue").countDocuments(),
+      this.db.collection('dialogue').countDocuments(),
     ])
     const { questions } = data[0]
     return { questions, dialogues }

--- a/packages/plugin-teach/src/database/mongo.ts
+++ b/packages/plugin-teach/src/database/mongo.ts
@@ -106,14 +106,13 @@ extendDatabase<typeof MongoDatabase>('koishi-plugin-mongo', {
 
   async getDialogueStats() {
     const [data, dialogues] = await Promise.all([
-      this.db.collection('dialogue').aggregate([
-        { $group: { _id: { $toLower: 'question' }, count: { $sum: 1 } } },
-        { $group: { _id: null, counts: { $push: { k: '$_id', v: '$count' } } } },
-        { $replaceRoot: { newRoot: { $arrayToObject: '$counts' } } },
+      this.db.collection("dialogue").aggregate([
+        { $group: { _id: null, questions: { $addToSet: '$question' } } },
+        { $project: { questions: { $size: '$questions' } } }
       ]).toArray(),
-      this.db.collection('dialogue').count(),
+      this.db.collection("dialogue").countDocuments(),
     ])
-    const questions = Object.keys(data).length
+    const { questions } = data[0]
     return { questions, dialogues }
   },
 })


### PR DESCRIPTION
- Fixed the counts of the number of questions
- Mongo driver: `collection.count` is deprecated, and will be removed in a future version. Use `Collection.countDocuments` or `Collection.estimatedDocumentCount` instead