### PR TITLE
Kaiheila Adapter: stable ping interval for websocket mode.

### DIFF
--- a/packages/adapter-kaiheila/src/bot.ts
+++ b/packages/adapter-kaiheila/src/bot.ts
@@ -18,6 +18,7 @@ export interface KaiheilaMessageInfo extends MessageInfo {
 export class KaiheilaBot extends Bot {
   _sn = 0
   _ping: NodeJS.Timeout
+  _heartbeat: NodeJS.Timeout
   version = 'kaiheila'
 
   static toMessage(data: KaiheilaMessageInfo & Record<string, any>) {


### PR DESCRIPTION
Websocket connection should be less likely to drop now.

- Swaped out `setTimeout` with `setInterval` and clear the interval with lazyness.
- Heartbeat timeout intervals are now 6s, 2s & 4s instead of ms.
- Added default endpoint config.