### PR TITLE
chore: fix broken links on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,14 @@ Koishi 原生地支持了多账户与跨平台，同时为这些机器人之间�
 
 ### 其他官方插件
 
-- [koishi-plugin-chess](https://koishi.js.org/plugins/other/chess.md) / 下棋
-- [koishi-plugin-github](https://koishi.js.org/plugins/other/github.md) / 接入 GitHub
-- [koishi-plugin-image-search](https://koishi.js.org/plugins/other/image-search.md) / 搜图
-- [koishi-plugin-puppeteer](https://koishi.js.org/plugins/other/puppeteer.md) / 网页截图
-- [koishi-plugin-rss](https://koishi.js.org/plugins/other/rss.md) / 订阅 RSS
-- [koishi-plugin-schedule](https://koishi.js.org/plugins/other/schedule.md) / 设置计划任务
-- [koishi-plugin-webui](https://koishi.js.org/plugins/other/webui.md) / 状态监控
-- [koishi-plugin-tools](https://koishi.js.org/plugins/other/tools.md) / 实用工具
+- [koishi-plugin-chess](https://koishi.js.org/plugins/other/chess) / 下棋
+- [koishi-plugin-github](https://koishi.js.org/plugins/other/github) / 接入 GitHub
+- [koishi-plugin-image-search](https://koishi.js.org/plugins/other/image-search) / 搜图
+- [koishi-plugin-puppeteer](https://koishi.js.org/plugins/other/puppeteer) / 网页截图
+- [koishi-plugin-rss](https://koishi.js.org/plugins/other/rss) / 订阅 RSS
+- [koishi-plugin-schedule](https://koishi.js.org/plugins/other/schedule) / 设置计划任务
+- [koishi-plugin-webui](https://koishi.js.org/plugins/other/webui) / 状态监控
+- [koishi-plugin-tools](https://koishi.js.org/plugins/other/tools) / 实用工具
 
 ## 使用协议
 


### PR DESCRIPTION
.md后缀会404，文档里的网址是.html后缀，不过不带后缀也可以跳转