### PR TITLE
feat(eval): add before-eval event

### DIFF
--- a/packages/plugin-eval/src/index.ts
+++ b/packages/plugin-eval/src/index.ts
@@ -33,6 +33,7 @@ declare module 'koishi-core' {
   interface EventMap {
     'eval/before-send'(content: string, session: Session): string | Promise<string>
     'eval/before-start'(): void | Promise<void>
+    'eval/before-eval'(script: string): string | Promise<string>
     'eval/start'(response: WorkerResponse): void
   }
 }
@@ -125,6 +126,7 @@ export function apply(ctx: Context, config: Config = {}) {
       return err.message
     }
 
+    expr = await ctx.waterfall('eval/before-eval', expr)
     return await new Promise((resolve) => {
       logger.debug(expr)
       defineProperty(session, '_isEval', true)


### PR DESCRIPTION
如果要在enhance里对eval的操作进行修改可能需要添加这个事件

1. 如果直接使用`command.action(xxx, true)`对jsx进行转换，则会拿到最原始的script，转换过后会变成js，其他语言的loader都无法生效，而且感觉挺别扭的
2. 如果使用js的loader，那么对于jsx，action无法运行到分发事件这里，因为没有经过转换的话jsx会被当成语法错误

所以如果需要enhance整合进eval需要有这个事件，并且enhance会根据loader的类型判断应该采用哪一种转换方案