### PR TITLE
plugin-common的请求处理系统，返回undefined无法通过类型检查

### DIFF
--- a/packages/plugin-common/src/handler.ts
+++ b/packages/plugin-common/src/handler.ts
@@ -87,13 +87,13 @@ export function repeater(ctx: Context, config: HandlerConfig) {
   })
 }
 
-type RequestHandler = string | boolean | ((session: Session) => string | boolean | Promise<string | boolean>)
+type RequestHandler = string | boolean | ((session: Session) => string | boolean | void | Promise<string | boolean | void>)
 
 async function getHandlerResult(handler: RequestHandler, session: Session, prefer: boolean): Promise<[boolean, string?]> {
   const result = typeof handler === 'function' ? await handler(session) : handler
   if (typeof result === 'string') {
     return [prefer, result]
-  } else if (result !== undefined) {
+  } else if (typeof result === 'boolean') {
     return [result]
   }
 }


### PR DESCRIPTION
文档中说请求处理函数返回undefined可以忽略请求，但实际开发时这样通不过类型检查。

修改了RequestHandler的定义，允许返回void类型。

----

（抱歉刚才没写完说明误开了pr