### PR TITLE
fix: recall is invalid on discord

### DIFF
--- a/packages/adapter-discord/src/bot.ts
+++ b/packages/adapter-discord/src/bot.ts
@@ -155,11 +155,10 @@ export class DiscordBot extends Bot<'discord'> {
       message_id: quote,
     } : undefined
 
-    const sentMessageId = await this.sendFullMessage(`/channels/${channelId}/messages`, session.content, { message_reference })
-    session.messageId = sentMessageId
+    session.messageId = await this.sendFullMessage(`/channels/${channelId}/messages`, session.content, { message_reference })
 
     this.app.emit(session, 'send', session)
-    return session.messageId = sentMessageId
+    return session.messageId
   }
 
   async deleteMessage(channelId: string, messageId: string) {

--- a/packages/adapter-discord/src/bot.ts
+++ b/packages/adapter-discord/src/bot.ts
@@ -156,6 +156,7 @@ export class DiscordBot extends Bot<'discord'> {
     } : undefined
 
     const sentMessageId = await this.sendFullMessage(`/channels/${channelId}/messages`, session.content, { message_reference })
+    session.messageId = sentMessageId
 
     this.app.emit(session, 'send', session)
     return session.messageId = sentMessageId

--- a/packages/plugin-common/src/basic.ts
+++ b/packages/plugin-common/src/basic.ts
@@ -179,7 +179,9 @@ export function recall(ctx: Context, { recallCount = 10 }: RecallConfig) {
     }
   })
 
-  ctx.command('common/recall [count:number]', '撤回 bot 发送的消息', { authority: 2 })
+  ctx
+    .group()
+    .command('common/recall [count:number]', '撤回 bot 发送的消息', { authority: 2 })
     .action(async ({ session }, count = 1) => {
       const list = recent[session.channelId]
       if (!list) return '近期没有发送消息。'

--- a/packages/plugin-common/src/basic.ts
+++ b/packages/plugin-common/src/basic.ts
@@ -168,10 +168,10 @@ export interface RecallConfig {
 }
 
 export function recall(ctx: Context, { recallCount = 10 }: RecallConfig) {
-  ctx = ctx.group()
   const recent: Record<string, string[]> = {}
 
   ctx.on('send', (session) => {
+    if (!session.channelId || session.subtype === 'private') return
     const list = recent[session.channelId] ||= []
     list.unshift(session.messageId)
     if (list.length > recallCount) {


### PR DESCRIPTION
- adapter-discord 在发送信息时不方便检查 subtype，所以我将 recall 里的选择器修改了一下
- adapter-discord 在 emit send 的时候忘记提供 messageId 了，我修了