### PR TITLE
fix(cli): make 'koishi start' works with koishi.config.yml

### DIFF
--- a/packages/koishi/src/worker.ts
+++ b/packages/koishi/src/worker.ts
@@ -24,11 +24,11 @@ if (process.env.KOISHI_CONFIG_FILE) {
   configDir = dirname(configFile)
 } else {
   const files = readdirSync(configDir)
-  const ext = ['.js', '.json', '.ts', '.yaml', '.yml'].find(ext => files.includes(basename + ext))
-  if (!ext) {
+  configExt = ['.js', '.json', '.ts', '.yaml', '.yml'].find(ext => files.includes(basename + ext))
+  if (!configExt) {
     throw new Error(`config file not found. use ${yellow('koishi init')} command to initialize a config file.`)
   }
-  configFile = configDir + '/' + basename + ext
+  configFile = configDir + '/' + basename + configExt
 }
 
 function loadConfig() {


### PR DESCRIPTION
<https://github.com/koishijs/koishi/blob/d11151502102eba899cca878c4ed5fa7f1d1dcfb/packages/koishi/src/worker.ts#L35>
使用 yml 配置文件的时候如果直接使用 `koishi start` 而没有指定配置文件的话这里的 `configExt` 会是 undefined ，修改之后如果存在文件 `configExt` 就不会是 undefined 从而达到加载 yml 文件的目的了