### PR TITLE
fix(mongo): Unset the default port 27017 to avoid MongoParseError

### DIFF
--- a/packages/plugin-mongo/src/database.ts
+++ b/packages/plugin-mongo/src/database.ts
@@ -37,7 +37,6 @@ export class MongoDatabase {
   constructor(public app: App, config?: Config) {
     this.config = {
       host: 'localhost',
-      port: 27017,
       name: 'koishi',
       protocol: 'mongodb',
       ...config,

--- a/packages/plugin-mongo/src/index.ts
+++ b/packages/plugin-mongo/src/index.ts
@@ -222,7 +222,7 @@ Database.extend(MongoDatabase, {
 export const name = 'mongo'
 
 export function apply(ctx: Context, config: Config) {
-  const db = new MongoDatabase(ctx.app, { host: 'localhost', port: 27017, name: 'koishi', protocol: 'mongodb', ...config })
+  const db = new MongoDatabase(ctx.app, { host: 'localhost', name: 'koishi', protocol: 'mongodb', ...config })
   ctx.database = db as any
   ctx.before('connect', () => db.start())
   ctx.before('disconnect', () => db.stop())


### PR DESCRIPTION
5e23361ea0336cf9f205627510c9886d72a88a32 [FIX] mongo: Unset the default port `27017` in order to avoid MongoParseError while using `mongodb+srv` protocol:

```
MongoParseError: Ports not accepted with 'mongodb+srv' URIs
```

The default value set in initialization is enough: https://github.com/koishijs/koishi/blob/8368dc7698430849dd06cf79e647164d8acf38ff/packages/koishi/src/init.ts#L152