### PR TITLE
chore(discord): add koishi-utils in dependencies

### DIFF
--- a/packages/adapter-discord/package.json
+++ b/packages/adapter-discord/package.json
@@ -33,7 +33,8 @@
   "devDependencies": {
     "@types/es-aggregate-error": "^1.0.2",
     "@types/ws": "^7.4.2",
-    "koishi-test-utils": "^6.0.1"
+    "koishi-test-utils": "^6.0.1",
+    "koishi-utils": "^4.2.3"
   },
   "dependencies": {
     "axios": "^0.21.1",


### PR DESCRIPTION
According to Yarn, the package should be declared explicitly in `package.json` if it was directly imported in the current module.

This change would prevent errors as below when using Yarn's [PnP feature](https://yarnpkg.com/features/pnp):

```
/app/.pnp.cjs:22495
    throw firstError;
    ^
Error: koishi-adapter-discord tried to access koishi-utils, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.***_1  |
Required package: koishi-utils
Required by: koishi-adapter-discord@virtual:3e7590c79a7a71e92dfdd4ef686edb228a2c300211e5a75fed1c59b8d8ff0c741dd862757451347836976645cf7f34b479512afc4dac67db51dfba314dab4cad#npm:1.3.2 (via /app/.yarn/__virtual__/koishi-adapter-discord-virtual-ea31ec39ae/0/cache/koishi-adapter-discord-npm-1.3.2-df15f5b2de-dc09b752f9.zip/node_modules/koishi-adapter-discord/lib/)
Require stack:
- /app/.yarn/__virtual__/koishi-adapter-discord-virtual-ea31ec39ae/0/cache/koishi-adapter-discord-npm-1.3.2-df15f5b2de-dc09b752f9.zip/node_modules/koishi-adapter-discord/lib/index.js
- /app/packages/***/dist/index.js
    at Function.external_module_.Module._resolveFilename (/app/.pnp.cjs:22494:55)
    at Function.external_module_.Module._load (/app/.pnp.cjs:22293:48)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:92:18)
    at Object.<anonymous> (/app/.yarn/__virtual__/koishi-adapter-discord-virtual-ea31ec39ae/0/cache/koishi-adapter-discord-npm-1.3.2-df15f5b2de-dc09b752f9.zip/node_modules/koishi-adapter-discord/lib/index.js:225:38)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.external_module_.Module._load (/app/.pnp.cjs:22343:14)
    at Module.require (internal/modules/cjs/loader.js:974:19)
```