### PR TITLE
fix(puppeteer): fix the failure to render the fragment from plugin-eval

### DIFF
--- a/packages/plugin-puppeteer/src/worker.ts
+++ b/packages/plugin-puppeteer/src/worker.ts
@@ -15,4 +15,4 @@ function wrapFactory<F extends (...args: any) => any>(func: F) {
 }
 
 internal.setGlobal(config.loaderConfig.jsxFactory, wrapFactory(createElement))
-internal.setGlobal(config.loaderConfig.jsxFragment, wrapFactory(Fragment))
+internal.setGlobal(config.loaderConfig.jsxFragment, Fragment)


### PR DESCRIPTION
Fragment 不是一个函数