### PR TITLE
docs: add dark/light theme for PanelView/ChatMessage

### DIFF
--- a/docs/.vuepress/components/ChatMessage.vue
+++ b/docs/.vuepress/components/ChatMessage.vue
@@ -135,8 +135,9 @@ $msgbox-left: 4.2rem;
   margin-left: $msgbox-left;
   width: fit-content;
   border-radius: 0.5rem;
-  background-color: white;
+  background-color: var(--c-bg);
   word-break: break-all;
+  transition: background-color ease 0.3s;
 
   .chat-message:not(.no-padding) &{
     padding: 0.5rem 0.7rem;
@@ -165,7 +166,8 @@ $msgbox-left: 4.2rem;
     border-bottom-width: 8px;
     border-bottom-color: currentColor;
     border-radius: 0 0 0 32px;
-    color: white;
+    color: var(--c-bg);
+    transition: color ease 0.3s;
   }
 
   p {
@@ -179,7 +181,9 @@ $msgbox-left: 4.2rem;
     border: none;
     border-radius: 0.5rem;
     padding: 0.2rem 0.6rem;
-    color: grayscale(10%);
+    background-color: var(--c-bg-light);
+    color: var(--c-text-lighter);
+    transition: background-color ease 0.3s, color ease 0.3s;
   }
 }
 

--- a/docs/.vuepress/components/PanelView.vue
+++ b/docs/.vuepress/components/PanelView.vue
@@ -94,7 +94,8 @@ $textShadow: 1px 1px 1px rgba(23, 31, 35, 0.5);
   border-radius: 6px;
   margin: 1rem 0;
   overflow-x: auto;
-  background-color: #f3f6f9;
+  background-color: var(--c-bg-light);
+  transition: background-color ease 0.3s;
 
   &.manager {
     background-color: #032f62;


### PR DESCRIPTION
之所以不为了 `ChatMessage` 给 `PanelView` 加 `chat` class 的原因有三：一方面是因为本来 `PanelView` 的默认情况也就基本都是 `ChatMessage` 在用，所以没有什么隐患；另一方面是因为目前的 `PanelView` 也没支持深色，所以顺便一并加了 variable 获取背景色；再一个如果要给所有的 Chat 都加新 class 的话改动太大了。

`transition` 的值全部是官方给定的值。
