### PR TITLE
docs(command): typo

### DIFF
--- a/docs/guide/command.md
+++ b/docs/guide/command.md
@@ -223,7 +223,7 @@ import { Argv } from 'koishi-core'
 declare module 'koishi-core' {
   namespace Argv {
     interface Domain {
-      int: number
+      positive: number
     }
   }
 }


### PR DESCRIPTION
文档这个 `int` 应该改成 `positive`