### PR TITLE
fix(test-utils): orm expr query behavior for `$eq`, `$ne` and so on

### DIFF
--- a/packages/koishi-test-utils/src/memory.ts
+++ b/packages/koishi-test-utils/src/memory.ts
@@ -65,8 +65,6 @@ const queryOperators: QueryOperators = {
 }
 
 function executeFieldQuery(query: Query.FieldQuery, data: any) {
-  if (!data) return false
-
   // shorthand syntax
   if (Array.isArray(query)) {
     return query.includes(data)
@@ -99,6 +97,7 @@ function executeQuery(query: Query.Expr, data: any): boolean {
     }
 
     // execute field query
+    if (!(key in data)) return false
     return executeFieldQuery(value, data[key])
   })
 }

--- a/packages/koishi-test-utils/src/memory.ts
+++ b/packages/koishi-test-utils/src/memory.ts
@@ -50,12 +50,12 @@ const queryOperators: QueryOperators = {
   $regexFor: (query, data) => new RegExp(data, 'i').test(query),
   $in: (query, data) => query.includes(data),
   $nin: (query, data) => !query.includes(data),
-  $ne: (query, data) => data !== query,
-  $eq: (query, data) => data === query,
-  $gt: (query, data) => data > query,
-  $gte: (query, data) => data >= query,
-  $lt: (query, data) => data < query,
-  $lte: (query, data) => data <= query,
+  $ne: (query, data) => data.valueOf() !== query.valueOf(),
+  $eq: (query, data) => data.valueOf() === query.valueOf(),
+  $gt: (query, data) => data.valueOf() > query.valueOf(),
+  $gte: (query, data) => data.valueOf() >= query.valueOf(),
+  $lt: (query, data) => data.valueOf() < query.valueOf(),
+  $lte: (query, data) => data.valueOf() <= query.valueOf(),
   $el: (query, data) => data.some(item => executeFieldQuery(query, item)),
   $size: (query, data) => data.length === query,
   $bitsAllSet: (query, data) => (query & data) === query,
@@ -65,6 +65,8 @@ const queryOperators: QueryOperators = {
 }
 
 function executeFieldQuery(query: Query.FieldQuery, data: any) {
+  if (!data) return false
+
   // shorthand syntax
   if (Array.isArray(query)) {
     return query.includes(data)

--- a/packages/koishi-test-utils/src/memory.ts
+++ b/packages/koishi-test-utils/src/memory.ts
@@ -97,8 +97,12 @@ function executeQuery(query: Query.Expr, data: any): boolean {
     }
 
     // execute field query
-    if (!(key in data)) return false
-    return executeFieldQuery(value, data[key])
+    try {
+      if (!(key in data)) return false
+      return executeFieldQuery(value, data[key])
+    } catch {
+      return false
+    }
   })
 }
 

--- a/packages/koishi-test-utils/tests/memory.spec.ts
+++ b/packages/koishi-test-utils/tests/memory.spec.ts
@@ -77,36 +77,22 @@ describe('Memory Database', () => {
     it('should convert date to primitives when doing comparisons', async () => {
       await expect(db.get('foo', {
         date: { $eq: new Date('2000-01-01') },
-      })).eventually.to
-        .have.nested.property('[0].bar')
-        .equal('awesome foo')
-
+      })).eventually.to.have.nested.property('[0].bar').equal('awesome foo')
       await expect(db.get('foo', {
         date: { $gte: new Date('2000-01-01') },
-      })).eventually.to
-        .have.nested.property('[0].bar')
-        .equal('awesome foo')
+      })).eventually.to.have.nested.property('[0].bar').equal('awesome foo')
     })
 
     it('compile expr query', async () => {
       await expect(db.get('foo', {
         id: 1,
-      })).eventually.to
-        .have.nested.property('[0].bar')
-        .equal('awesome foo')
-
+      })).eventually.to.have.nested.property('[0].bar').equal('awesome foo')
       await expect(db.get('foo', {
         id: { $eq: 1 },
-      })).eventually.to
-        .have.nested.property('[0].bar')
-        .equal('awesome foo')
-
+      })).eventually.to.have.nested.property('[0].bar').equal('awesome foo')
       await expect(db.get('foo', {
         id: { $gt: 1 },
-      })).eventually.to
-        .have.nested.property('[0].bar')
-        .equal('awesome bar')
-
+      })).eventually.to.have.nested.property('[0].bar').equal('awesome bar')
       await expect(db.get('foo', {
         id: { $lt: 1 },
       })).eventually.to.have.length(0)
@@ -116,7 +102,6 @@ describe('Memory Database', () => {
       await expect(db.get('foo', {
         id: { $in: [] },
       })).eventually.to.have.length(0)
-
       await expect(db.get('foo', {
         id: { $nin: [] },
       })).eventually.to.have.length(3)
@@ -135,17 +120,13 @@ describe('Memory Database', () => {
     it('filter data by regex', async () => {
       await expect(db.get('foo', {
         bar: /^.*foo$/,
-      })).eventually.to
-        .have.nested.property('[0].bar')
-        .equal('awesome foo')
+      })).eventually.to.have.nested.property('[0].bar').equal('awesome foo')
 
       await expect(db.get('foo', {
         bar: {
           $regex: /^.*foo$/,
         },
-      })).eventually.to
-        .have.nested.property('[0].bar')
-        .equal('awesome foo')
+      })).eventually.to.have.nested.property('[0].bar').equal('awesome foo')
 
       await expect(db.get('foo', {
         bar: /^.*foo.*$/,
@@ -156,15 +137,12 @@ describe('Memory Database', () => {
       await expect(db.get('foo', {
         baz: { $bitsAllSet: 3 },
       })).eventually.to.have.shape([{ baz: 3 }, { baz: 7 }])
-
       await expect(db.get('foo', {
         baz: { $bitsAllClear: 9 },
       })).eventually.to.have.shape([{ baz: 4 }])
-
       await expect(db.get('foo', {
         baz: { $bitsAnySet: 4 },
       })).eventually.to.have.shape([{ baz: 4 }, { baz: 7 }])
-
       await expect(db.get('foo', {
         baz: { $bitsAnyClear: 6 },
       })).eventually.to.have.shape([{ baz: 3 }, { baz: 4 }])
@@ -174,11 +152,9 @@ describe('Memory Database', () => {
       await expect(db.get('foo', {
         list: { $size: 1 },
       })).eventually.to.have.shape([{ baz: 4 }, { baz: 7 }])
-
       await expect(db.get('foo', {
         list: { $el: 100 },
       })).eventually.to.have.shape([{ baz: 7 }])
-
       await expect(db.get('foo', {
         list: { $el: { $lt: 50 } },
       })).eventually.to.have.shape([{ baz: 4 }])
@@ -192,7 +168,6 @@ describe('Memory Database', () => {
           id: [1, 3],
         }],
       })).eventually.to.have.length(3)
-
       await expect(db.get('foo', {
         $or: [{
           id: [2],
@@ -200,7 +175,6 @@ describe('Memory Database', () => {
           bar: /.*foo.*/,
         }],
       })).eventually.to.have.length(3)
-
       await expect(db.get('foo', {
         $or: [{
           id: { $gt: 1 },
@@ -208,19 +182,15 @@ describe('Memory Database', () => {
           bar: /.*foo$/,
         }],
       })).eventually.to.have.length(3)
-
       await expect(db.get('foo', {
         $or: [{ bar: /.*foo/ }, { bar: /foo.*/ }],
       })).eventually.to.have.length(2)
-
       await expect(db.get('foo', {
         $and: [{ bar: /.*foo$/ }, { bar: /foo.*/ }],
       })).eventually.to.have.length(1)
-
       await expect(db.get('foo', {
         $not: { $and: [{ bar: /.*foo$/ }, { bar: /foo.*/ }] },
       })).eventually.to.have.length(2)
-
       await expect(db.get('foo', {
         $not: { $or: [{ bar: /.*foo/ }, { bar: /foo.*/ }] },
       })).eventually.to.have.length(1)
@@ -233,7 +203,6 @@ describe('Memory Database', () => {
           bar: /.*foo/,
         }],
       })).eventually.to.have.length(2)
-
       await expect(db.get('foo', {
         bar: /.*foo.*/,
         $or: [{

--- a/packages/koishi-test-utils/tests/memory.spec.ts
+++ b/packages/koishi-test-utils/tests/memory.spec.ts
@@ -78,6 +78,7 @@ describe('Memory Database', () => {
       await expect(db.get('foo', {
         date: { $eq: new Date('2000-01-01') },
       })).eventually.to.have.nested.property('[0].bar').equal('awesome foo')
+
       await expect(db.get('foo', {
         date: { $gte: new Date('2000-01-01') },
       })).eventually.to.have.nested.property('[0].bar').equal('awesome foo')
@@ -87,12 +88,15 @@ describe('Memory Database', () => {
       await expect(db.get('foo', {
         id: 1,
       })).eventually.to.have.nested.property('[0].bar').equal('awesome foo')
+
       await expect(db.get('foo', {
         id: { $eq: 1 },
       })).eventually.to.have.nested.property('[0].bar').equal('awesome foo')
+
       await expect(db.get('foo', {
         id: { $gt: 1 },
       })).eventually.to.have.nested.property('[0].bar').equal('awesome bar')
+
       await expect(db.get('foo', {
         id: { $lt: 1 },
       })).eventually.to.have.length(0)
@@ -102,6 +106,7 @@ describe('Memory Database', () => {
       await expect(db.get('foo', {
         id: { $in: [] },
       })).eventually.to.have.length(0)
+
       await expect(db.get('foo', {
         id: { $nin: [] },
       })).eventually.to.have.length(3)
@@ -137,12 +142,15 @@ describe('Memory Database', () => {
       await expect(db.get('foo', {
         baz: { $bitsAllSet: 3 },
       })).eventually.to.have.shape([{ baz: 3 }, { baz: 7 }])
+
       await expect(db.get('foo', {
         baz: { $bitsAllClear: 9 },
       })).eventually.to.have.shape([{ baz: 4 }])
+
       await expect(db.get('foo', {
         baz: { $bitsAnySet: 4 },
       })).eventually.to.have.shape([{ baz: 4 }, { baz: 7 }])
+
       await expect(db.get('foo', {
         baz: { $bitsAnyClear: 6 },
       })).eventually.to.have.shape([{ baz: 3 }, { baz: 4 }])
@@ -152,9 +160,11 @@ describe('Memory Database', () => {
       await expect(db.get('foo', {
         list: { $size: 1 },
       })).eventually.to.have.shape([{ baz: 4 }, { baz: 7 }])
+
       await expect(db.get('foo', {
         list: { $el: 100 },
       })).eventually.to.have.shape([{ baz: 7 }])
+
       await expect(db.get('foo', {
         list: { $el: { $lt: 50 } },
       })).eventually.to.have.shape([{ baz: 4 }])
@@ -168,6 +178,7 @@ describe('Memory Database', () => {
           id: [1, 3],
         }],
       })).eventually.to.have.length(3)
+
       await expect(db.get('foo', {
         $or: [{
           id: [2],
@@ -175,6 +186,7 @@ describe('Memory Database', () => {
           bar: /.*foo.*/,
         }],
       })).eventually.to.have.length(3)
+
       await expect(db.get('foo', {
         $or: [{
           id: { $gt: 1 },
@@ -182,15 +194,19 @@ describe('Memory Database', () => {
           bar: /.*foo$/,
         }],
       })).eventually.to.have.length(3)
+
       await expect(db.get('foo', {
         $or: [{ bar: /.*foo/ }, { bar: /foo.*/ }],
       })).eventually.to.have.length(2)
+
       await expect(db.get('foo', {
         $and: [{ bar: /.*foo$/ }, { bar: /foo.*/ }],
       })).eventually.to.have.length(1)
+
       await expect(db.get('foo', {
         $not: { $and: [{ bar: /.*foo$/ }, { bar: /foo.*/ }] },
       })).eventually.to.have.length(2)
+
       await expect(db.get('foo', {
         $not: { $or: [{ bar: /.*foo/ }, { bar: /foo.*/ }] },
       })).eventually.to.have.length(1)
@@ -203,6 +219,7 @@ describe('Memory Database', () => {
           bar: /.*foo/,
         }],
       })).eventually.to.have.length(2)
+
       await expect(db.get('foo', {
         bar: /.*foo.*/,
         $or: [{

--- a/packages/koishi-test-utils/tests/memory.spec.ts
+++ b/packages/koishi-test-utils/tests/memory.spec.ts
@@ -19,6 +19,7 @@ interface FooData {
   bar: string
   baz?: number
   list?: number[]
+  datetime?: Date
 }
 
 Tables.extend('foo')
@@ -63,7 +64,7 @@ describe('Memory Database', () => {
 
   describe('complex expression', () => {
     before(async () => {
-      await db.createFoo({ bar: 'awesome foo', baz: 3, list: [] })
+      await db.createFoo({ bar: 'awesome foo', baz: 3, list: [], datetime: new Date('2000-01-01') })
       await db.createFoo({ bar: 'awesome bar', baz: 4, list: [1] })
       await db.createFoo({ bar: 'awesome foo bar', baz: 7, list: [100] })
     })
@@ -71,6 +72,20 @@ describe('Memory Database', () => {
     after(() => {
       // clear memory data, prevent the following single test from being affected
       db.memory.$store.foo = []
+    })
+
+    it('should check in addition to basic types.', async () => {
+      await expect(db.get('foo', {
+        datetime: { $eq: new Date('2000-01-01') },
+      })).eventually.to
+        .have.nested.property('[0].bar')
+        .equal('awesome foo')
+
+      await expect(db.get('foo', {
+        datetime: { $gte: new Date('2000-01-01') },
+      })).eventually.to
+        .have.nested.property('[0].bar')
+        .equal('awesome foo')
     })
 
     it('compile expr query', async () => {

--- a/packages/koishi-test-utils/tests/memory.spec.ts
+++ b/packages/koishi-test-utils/tests/memory.spec.ts
@@ -19,7 +19,7 @@ interface FooData {
   bar: string
   baz?: number
   list?: number[]
-  datetime?: Date
+  date?: Date
 }
 
 Tables.extend('foo')
@@ -64,7 +64,7 @@ describe('Memory Database', () => {
 
   describe('complex expression', () => {
     before(async () => {
-      await db.createFoo({ bar: 'awesome foo', baz: 3, list: [], datetime: new Date('2000-01-01') })
+      await db.createFoo({ bar: 'awesome foo', baz: 3, list: [], date: new Date('2000-01-01') })
       await db.createFoo({ bar: 'awesome bar', baz: 4, list: [1] })
       await db.createFoo({ bar: 'awesome foo bar', baz: 7, list: [100] })
     })
@@ -74,15 +74,15 @@ describe('Memory Database', () => {
       db.memory.$store.foo = []
     })
 
-    it('should check in addition to basic types.', async () => {
+    it('should convert date to primitives when doing comparisons', async () => {
       await expect(db.get('foo', {
-        datetime: { $eq: new Date('2000-01-01') },
+        date: { $eq: new Date('2000-01-01') },
       })).eventually.to
         .have.nested.property('[0].bar')
         .equal('awesome foo')
 
       await expect(db.get('foo', {
-        datetime: { $gte: new Date('2000-01-01') },
+        date: { $gte: new Date('2000-01-01') },
       })).eventually.to
         .have.nested.property('[0].bar')
         .equal('awesome foo')


### PR DESCRIPTION
#338