### PR TITLE
Export `renderText` function to support extrenal use

### DIFF
--- a/plugins/adapter/onebot/src/bot.ts
+++ b/plugins/adapter/onebot/src/bot.ts
@@ -1,7 +1,7 @@
 import { Bot, segment, Adapter, Dict, Schema, Quester, Logger, camelize } from 'koishi'
 import * as OneBot from './utils'
 
-function renderText(source: string) {
+export function renderText(source: string) {
   return segment.parse(source).reduce((prev, { type, data }) => {
     if (type === 'at') {
       if (data.type === 'all') return prev + '[CQ:at,qq=all]'


### PR DESCRIPTION
构造合并转发的时候有用, 因为此时合并转发内容不会经过该函数, 需要用户自行处理