### PR TITLE
koishi: start http server but dont listen if no port

### DIFF
--- a/packages/koishi/src/router.ts
+++ b/packages/koishi/src/router.ts
@@ -108,27 +108,27 @@ export class Router extends KoaRouter {
     app._wsServer = new WebSocket.Server({
       server: app._httpServer,
     })
-
-    app.on('connect', () => {
-      const { port, host } = app.options
-      if (!port) return
-
-      app._httpServer.listen(port, host)
-      app.logger('app').info('server listening at %c', `http://${host || 'localhost'}:${port}`)
-    })
-
-    app.on('disconnect', () => {
-      if (!app.options.port) return
-      app.logger('app').info('http server closing')
-      app._wsServer?.close()
-      app._httpServer?.close()
-    })
-
+    
     app._wsServer.on('connection', (socket, request) => {
       for (const manager of app.router.wsStack) {
         if (manager.accept(socket, request)) return
       }
       socket.close()
     })
+    
+    const { port,  host } = app.options
+    if (!port) return
+
+    app.on('connect', () => {
+      app._httpServer.listen(port, host)
+      app.logger('app').info('server listening at %c', `http://${host || 'localhost'}:${port}`)
+    })
+
+    app.on('disconnect', () => {
+      app.logger('app').info('http server closing')
+      app._wsServer?.close()
+      app._httpServer?.close()
+    })
+
   }
 }

--- a/packages/koishi/src/router.ts
+++ b/packages/koishi/src/router.ts
@@ -97,9 +97,6 @@ export class Router extends KoaRouter {
   static prepare(app: App) {
     app.options.baseDir ||= process.cwd()
 
-    const { port, host } = app.options
-    if (!port) return
-
     // create server
     const koa = new Koa()
     app.router = new Router()
@@ -113,11 +110,15 @@ export class Router extends KoaRouter {
     })
 
     app.on('connect', () => {
+      const { port, host } = app.options
+      if (!port) return
+
       app._httpServer.listen(port, host)
       app.logger('app').info('server listening at %c', `http://${host || 'localhost'}:${port}`)
     })
 
     app.on('disconnect', () => {
+      if (!app.options.port) return
       app.logger('app').info('http server closing')
       app._wsServer?.close()
       app._httpServer?.close()


### PR DESCRIPTION
Mainly used for mock.

Before:

```ts
const app = new App();
console.log(app._httpServer); // undefined
```

After:

```ts
const app = new App();
console.log(app._httpServer); // an http server
```