### PR TITLE
Change some types in MySQL

### DIFF
--- a/plugins/database/mysql/src/index.ts
+++ b/plugins/database/mysql/src/index.ts
@@ -38,13 +38,13 @@ function getTypeDefinition({ type, length, precision, scale }: Model.Field) {
     case 'float':
     case 'double':
     case 'date':
-    case 'time':
-    case 'timestamp': return type
+    case 'time': return type
+    case 'datetime': return 'datetime'
     case 'integer': return getIntegerType(length)
     case 'unsigned': return `${getIntegerType(length)} unsigned`
     case 'decimal': return `decimal(${precision}, ${scale}) unsigned`
     case 'char': return `char(${length || 255})`
-    case 'string': return `char(${length || 255})`
+    case 'string': return `varchar(${length || 255})`
     case 'text': return `text(${length || 65535})`
     case 'list': return `text(${length || 65535})`
     case 'json': return `text(${length || 65535})`

--- a/plugins/database/mysql/src/index.ts
+++ b/plugins/database/mysql/src/index.ts
@@ -39,7 +39,7 @@ function getTypeDefinition({ type, length, precision, scale }: Model.Field) {
     case 'double':
     case 'date':
     case 'time': return type
-    case 'datetime': return 'datetime'
+    case 'timestamp': return 'datetime'
     case 'integer': return getIntegerType(length)
     case 'unsigned': return `${getIntegerType(length)} unsigned`
     case 'decimal': return `decimal(${precision}, ${scale}) unsigned`


### PR DESCRIPTION
The following changes are made for the following reason:

1. `char` would use the maximum length to store every string, no matter how long the data stored is. In practice, as for the situations where strings hardly touches the limit, it's better to use `varchar` instead of `char`.

2. `timestamp` is not recommended to use in MySQL, as it may meet the year 2038 problem.