### PR TITLE
chore: axios stream data is internal.Readable rather than NodeJS.ReadableStream

### DIFF
--- a/packages/koishi/src/quester.ts
+++ b/packages/koishi/src/quester.ts
@@ -3,6 +3,7 @@ import { Dict, defineProperty } from '@koishijs/utils'
 import { Agent } from 'http'
 import ProxyAgent from 'proxy-agent'
 import axios, { AxiosRequestConfig, Method } from 'axios'
+import internal from 'stream'
 
 declare module '@koishijs/core' {
   namespace App {
@@ -54,7 +55,7 @@ export namespace Quester {
 
   export interface Get {
     <T = any>(url: string, params?: Dict, headers?: Dict): Promise<T>
-    stream(url: string, params?: Dict, headers?: Dict): Promise<ReadableStream>
+    stream(url: string, params?: Dict, headers?: Dict): Promise<internal.Readable>
     arraybuffer(url: string, params?: Dict, headers?: Dict): Promise<ArrayBuffer>
   }
 


### PR DESCRIPTION
According to [Axios docs](https://axios-http.com/docs/req_config), `axios.get` with `responseType: 'stream'` returns `internal.Readable` as data, rather than the old-fashioned `NodeJS.ReadableStream`. As a result, Quester users had been leaded to confusion.
In fact, according to [Node.js docs](https://nodejs.org/api/stream.html#compatibility-with-older-nodejs-versions), `NodeJS.ReadableStream` is deprecated.
Patched Quester type def and go-cqhttp installer.
