### PR TITLE
fix: undefined reading error in request function

### DIFF
--- a/packages/koishi/src/quester.ts
+++ b/packages/koishi/src/quester.ts
@@ -77,7 +77,7 @@ export namespace Quester {
       url: endpoint + url,
       headers: {
         ...options.headers,
-        ...config.headers,
+        ...config?.headers,
       },
     })
 

--- a/packages/koishi/src/quester.ts
+++ b/packages/koishi/src/quester.ts
@@ -71,13 +71,13 @@ export namespace Quester {
       options.httpsAgent = getAgent(config.proxyAgent)
     }
 
-    const request = async (url: string, config?: AxiosRequestConfig) => axios({
+    const request = async (url: string, config: AxiosRequestConfig = {}) => axios({
       ...options,
       ...config,
       url: endpoint + url,
       headers: {
         ...options.headers,
-        ...config?.headers,
+        ...config.headers,
       },
     })
 


### PR DESCRIPTION
Because the `config` in the function is an optional argument, it can be undefined.
And then the code below read its property without an optional notation, so cause the error like:
` TypeError: Cannot read properties of undefined (reading 'headers')`
This PR fixes the error.