### PR TITLE
fix(plugin-forward): can not throw error

### DIFF
--- a/plugins/common/forward/src/index.ts
+++ b/plugins/common/forward/src/index.ts
@@ -73,7 +73,7 @@ export function apply(ctx: Context, { rules, interval }: Config) {
       if (session.cid !== options.source) continue
       tasks.push(sendRelay(session, options))
     }
-    const [result] = await Promise.all([next(), Promise.allSettled(tasks)])
+    const [result] = await Promise.all([next(), ...tasks])
     return result
   })
 


### PR DESCRIPTION
`Promise.allSettled` can not throw database error, it makes it difficult to debug(when we didn't write `selfId`).

In `sendRelay` function, we has:

```ts
if (!ctx.database) throw new Error('database service is required when selfId is not specified')
```

After I modify it, it can throw errors normally.