### PR TITLE
feat(assets): skip upload when from same origin

### DIFF
--- a/plugins/assets/local/src/index.ts
+++ b/plugins/assets/local/src/index.ts
@@ -77,6 +77,7 @@ class LocalAssets extends Assets {
   }
 
   async upload(url: string, file: string) {
+    if (url.startsWith(this.config.selfUrl)) return url
     await this._promise
     const { selfUrl, path, root } = this.config
     const { buffer, filename } = await this.analyze(url, file)

--- a/plugins/assets/remote/src/index.ts
+++ b/plugins/assets/remote/src/index.ts
@@ -20,6 +20,7 @@ class RemoteAssets extends Assets {
   stop() {}
 
   async upload(url: string, file: string) {
+    if (url.startsWith(this.config.endpoint)) return url
     const { secret } = this.config
     const params = { url, file } as any
     if (secret) {

--- a/plugins/assets/s3/src/index.ts
+++ b/plugins/assets/s3/src/index.ts
@@ -36,6 +36,9 @@ class S3Assets extends Assets {
   }
 
   async upload(url: string, file: string) {
+    if (url.startsWith(this.config.publicUrl) || typeof this.config.endpoint === 'string' && url.startsWith(this.config.endpoint)) {
+      return url
+    }
     const { buffer, filename } = await this.analyze(url, file)
     const s3Key = `${this.config.pathPrefix}${filename}`
     const finalUrl = `${this.config.publicUrl}${filename}`

--- a/plugins/assets/s3/src/index.ts
+++ b/plugins/assets/s3/src/index.ts
@@ -36,7 +36,7 @@ class S3Assets extends Assets {
   }
 
   async upload(url: string, file: string) {
-    if (url.startsWith(this.config.publicUrl) || typeof this.config.endpoint === 'string' && url.startsWith(this.config.endpoint)) {
+    if (url.startsWith(this.config.publicUrl)) {
       return url
     }
     const { buffer, filename } = await this.analyze(url, file)


### PR DESCRIPTION
When the asset file originates from the assets storage provider itself, skips the entire upload process and return the url directly.