### PR TITLE
feat(forward): add useAssets

### DIFF
--- a/plugins/common/forward/package.json
+++ b/plugins/common/forward/package.json
@@ -30,7 +30,8 @@
     "plugin",
     "relay",
     "forward",
-    "optional:database"
+    "optional:database",
+    "optional:assets"
   ],
   "peerDependencies": {
     "koishi": "^4.2.0"


### PR DESCRIPTION
Added `useAssets` option to make every media of  forward messages stored by assets, making sure the messages not failing.