### PR TITLE
fix(database-memory): data not loading (#519)

### DIFF
--- a/plugins/database/memory/src/storage/node.ts
+++ b/plugins/database/memory/src/storage/node.ts
@@ -26,11 +26,11 @@ export class Storage {
     const files = await fs.readdir(root)
     await Promise.all(files.map(async (filename) => {
       const extension = extname(filename)
-      if (extension !== loader) return
-      const buffer = await fs.readFile(filename)
+      if (extension !== `.${loader}`) return
+      const buffer = await fs.readFile(resolve(root, filename))
       try {
         const data = await this.load(buffer, loader)
-        const name = filename.slice(0, -1 - extension.length)
+        const name = filename.slice(0, filename.length - extension.length)
         tables[name] = data
       } catch {}
     }))


### PR DESCRIPTION
fixed to make Storage.start() work (probably)
----
fixes #519
>looks like someone didn't realize that `path.extname()` includes the preceeding dot