### PR TITLE
chore: remove option port assertions

### DIFF
--- a/plugins/adapter/kaiheila/src/http.ts
+++ b/plugins/adapter/kaiheila/src/http.ts
@@ -14,7 +14,6 @@ export default class HttpServer extends Adapter<BotConfig, AdapterConfig> {
   ])
 
   constructor(ctx: Context, config: AdapterConfig) {
-    assertProperty(ctx.app.options, 'port')
     config.path = sanitize(config.path || '/kaiheila')
     super(ctx, config)
   }

--- a/plugins/adapter/kaiheila/src/http.ts
+++ b/plugins/adapter/kaiheila/src/http.ts
@@ -1,4 +1,4 @@
-import { Adapter, assertProperty, Context, Logger, Quester, sanitize, Schema } from 'koishi'
+import { Adapter, Context, Logger, Quester, sanitize, Schema } from 'koishi'
 import { BotConfig, KaiheilaBot } from './bot'
 import { AdapterConfig, adaptSession } from './utils'
 

--- a/plugins/adapter/onebot/src/http.ts
+++ b/plugins/adapter/onebot/src/http.ts
@@ -18,7 +18,6 @@ export class HttpServer extends Adapter<BotConfig, AdapterConfig> {
 
   constructor(ctx: Context, config: AdapterConfig = {}) {
     super(ctx, config)
-    assertProperty(ctx.app.options, 'port')
   }
 
   async connect(bot: OneBotBot) {

--- a/plugins/adapter/onebot/src/http.ts
+++ b/plugins/adapter/onebot/src/http.ts
@@ -1,4 +1,4 @@
-import { Adapter, Context, Logger, omit, Quester, Schema } from 'koishi'
+import { Adapter, Logger, omit, Quester, Schema } from 'koishi'
 import { BotConfig, OneBotBot } from './bot'
 import { AdapterConfig, dispatchSession } from './utils'
 import { createHmac } from 'crypto'

--- a/plugins/adapter/onebot/src/http.ts
+++ b/plugins/adapter/onebot/src/http.ts
@@ -16,10 +16,6 @@ export class HttpServer extends Adapter<BotConfig, AdapterConfig> {
 
   public bots: OneBotBot[]
 
-  constructor(ctx: Context, config: AdapterConfig = {}) {
-    super(ctx, config)
-  }
-
   async connect(bot: OneBotBot) {
     const { endpoint, token } = bot.config
     if (!endpoint) return

--- a/plugins/adapter/onebot/src/http.ts
+++ b/plugins/adapter/onebot/src/http.ts
@@ -1,4 +1,4 @@
-import { Adapter, assertProperty, Context, Logger, omit, Quester, Schema } from 'koishi'
+import { Adapter, Context, Logger, omit, Quester, Schema } from 'koishi'
 import { BotConfig, OneBotBot } from './bot'
 import { AdapterConfig, dispatchSession } from './utils'
 import { createHmac } from 'crypto'

--- a/plugins/adapter/onebot/src/ws.ts
+++ b/plugins/adapter/onebot/src/ws.ts
@@ -1,4 +1,4 @@
-import { Adapter, assertProperty, Context, Logger, Schema, Time, WebSocketLayer } from 'koishi'
+import { Adapter, Context, Logger, Schema, Time, WebSocketLayer } from 'koishi'
 import { BotConfig, OneBotBot } from './bot'
 import { AdapterConfig, dispatchSession, Response } from './utils'
 import WebSocket from 'ws'

--- a/plugins/adapter/onebot/src/ws.ts
+++ b/plugins/adapter/onebot/src/ws.ts
@@ -35,7 +35,6 @@ export class WebSocketServer extends Adapter<BotConfig, AdapterConfig> {
 
   constructor(ctx: Context, config: AdapterConfig) {
     super(ctx, config)
-    assertProperty(ctx.app.options, 'port')
     const { path = '/onebot' } = config
 
     this.wsServer = ctx.router.ws(path, (socket, { headers }) => {


### PR DESCRIPTION
There are situations where http server would response without actually make the inbuilt http server listen. In those cases this option assertion could only be annoying.

The situations could be as follows:

- `koishi-nestjs` sharing the same http server with Nest instance, using Nest middleware to redirect requests.
- `koishi-web-connect` exporting router services as Express middlewares.
- `@koishijs/plugin-mock` mocking http requests.