### PR TITLE
fix(mongo): db.totalSize can be undefined, fix #568

### DIFF
--- a/plugins/database/mongo/src/index.ts
+++ b/plugins/database/mongo/src/index.ts
@@ -119,10 +119,15 @@ class MongoDatabase extends Database {
 
   async stats() {
     // https://docs.mongodb.com/manual/reference/command/dbStats/#std-label-dbstats-output
-    const [{ totalSize }, tables] = await Promise.all([
+    const [stats, tables] = await Promise.all([
       this.db.stats(),
       this._collStats(),
     ])
+    // https://www.mongodb.com/docs/manual/reference/command/dbStats/#mongodb-data-dbStats.totalSize
+    // While MongoDB's document above says that the `stats.totalSize` is the sum of
+    // `stats.dataSize` and `stats.storageSize`, it's actually `undefined` in some cases.
+    // So we have to calculate it manually.
+    const totalSize = stats.indexSize + stats.storageSize
     return { size: totalSize, tables }
   }
 

--- a/plugins/database/mongo/src/index.ts
+++ b/plugins/database/mongo/src/index.ts
@@ -123,7 +123,6 @@ class MongoDatabase extends Database {
       this.db.stats(),
       this._collStats(),
     ])
-    // https://www.mongodb.com/docs/manual/reference/command/dbStats/#mongodb-data-dbStats.totalSize
     // While MongoDB's document above says that the `stats.totalSize` is the sum of
     // `stats.dataSize` and `stats.storageSize`, it's actually `undefined` in some cases.
     // So we have to calculate it manually.


### PR DESCRIPTION
https://www.mongodb.com/docs/manual/reference/command/dbStats/#mongodb-data-dbStats.totalSize
While MongoDB's document above says that the `stats.totalSize` is the sum of
 `stats.dataSize` and `stats.storageSize`, it's actually `undefined` in some cases.
So we have to calculate it manually.