### PR TITLE
fix(core): ws error caused by empty proxyAgent

### DIFF
--- a/packages/koishi/src/quester.ts
+++ b/packages/koishi/src/quester.ts
@@ -100,7 +100,7 @@ export namespace Quester {
 
     http.ws = (url, options = {}) => {
       return new WebSocket(url, {
-        agent: getAgent(config.proxyAgent),
+        agent: config.proxyAgent && getAgent(config.proxyAgent),
         handshakeTimeout: config.timeout,
         ...options,
         headers: {


### PR DESCRIPTION
解决空代理导致的 websocket 错误

Koishi 4.6.1
go-cqhttp 1.0.0-rc1
当`proxyAgent`为空时使用正向ws连接将报错：
```
[WARNING]: 处理 WebSocket 请求时出现错误: websocket: the client is not using the websocket protocol: 'upgrade' token not found in 'Connection' header
```