### PR TITLE
feat(adapter-onebot): new event 'message-self'

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -15,6 +15,7 @@ declare module './context' {
     'message': SessionEventCallback
     'message-deleted': SessionEventCallback
     'message-updated': SessionEventCallback
+    'message-self': SessionEventCallback
     'reaction-added': SessionEventCallback
     'reaction-deleted': SessionEventCallback
     'reaction-deleted/one': SessionEventCallback

--- a/plugins/adapter/onebot/src/utils.ts
+++ b/plugins/adapter/onebot/src/utils.ts
@@ -141,6 +141,14 @@ export function adaptSession(data: OneBot.Payload) {
     return session
   }
 
+  if (data.post_type === 'message_sent') {
+    Object.assign(session, adaptMessage(data))
+    session.subtype = data.message_type === 'guild' ? 'group' : data.message_type
+    session.subsubtype = data.message_type
+    session.type = "message-self";
+    return session
+  }
+
   session.subtype = data.sub_type
   if (data.user_id) session.userId = '' + data.user_id
   if (data.group_id) session.guildId = session.channelId = '' + data.group_id


### PR DESCRIPTION
添加新事件`message-self`并在onebot适配器中实现
需要在go-cqhttp配置打开`message.report-self-message`项