### PR TITLE
ci: restrict some workflows runs in main repo only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,7 @@ jobs:
           name: codecov
 
   docs:
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.repository == 'koishijs/koishi' && github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     needs:
       - prepare
@@ -210,7 +210,7 @@ jobs:
           force_orphan: true
 
   docs-next:
-    if: ${{ github.ref == 'refs/heads/next' }}
+    if: ${{ github.repository == 'koishijs/koishi' && github.ref == 'refs/heads/next' }}
     runs-on: ubuntu-latest
     needs:
       - prepare

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   publish-dockerhub:
+    if: ${{ github.repository == 'koishijs/koishi' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   stale:
+    if: ${{ github.repository == 'koishijs/koishi' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v4


### PR DESCRIPTION
As the title says, these workflows / steps should not run on a fork.
So add an if-check there.