### PR TITLE
fix(utils): resolve error failed when stack is undefined

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -31,8 +31,8 @@ export function assertProperty<O, K extends keyof O & string>(config: O, key: K)
 }
 
 export function coerce(val: any) {
-  const { message, stack } = val instanceof Error ? val : new Error(val as any)
-  const lines = stack ? stack.split('\n') : []
+  const { message, stack } = val instanceof Error && val.stack ? val : new Error(val as any)
+  const lines = stack.split('\n')
   const index = lines.findIndex(line => line.endsWith(message))
   return lines.slice(index).join('\n')
 }

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -32,7 +32,7 @@ export function assertProperty<O, K extends keyof O & string>(config: O, key: K)
 
 export function coerce(val: any) {
   const { message, stack } = val instanceof Error ? val : new Error(val as any)
-  const lines = stack.split('\n')
+  const lines = stack ? stack.split('\n') : []
   const index = lines.findIndex(line => line.endsWith(message))
   return lines.slice(index).join('\n')
 }

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -31,7 +31,7 @@ export function assertProperty<O, K extends keyof O & string>(config: O, key: K)
 }
 
 export function coerce(val: any) {
-  // resolve error when stack is undefined
+  // resolve error when stack is undefined, e.g. axios error with status code 401
   const { message, stack } = val instanceof Error && val.stack ? val : new Error(val as any)
   const lines = stack.split('\n')
   const index = lines.findIndex(line => line.endsWith(message))

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -31,6 +31,7 @@ export function assertProperty<O, K extends keyof O & string>(config: O, key: K)
 }
 
 export function coerce(val: any) {
+  // resolve error when stack is undefined
   const { message, stack } = val instanceof Error && val.stack ? val : new Error(val as any)
   const lines = stack.split('\n')
   const index = lines.findIndex(line => line.endsWith(message))


### PR DESCRIPTION
处理的错误若 error.stack = undefined（如 axios 库的 401 response）会在这行挂掉。