### PR TITLE
feat(core): support generator function as command action

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -2,6 +2,10 @@ export function isInteger(source: any) {
   return typeof source === 'number' && Math.floor(source) === source
 }
 
+export function isGeneratorFunction<T = unknown, TReturn = any, TNext = unknown>(fn: any): fn is (...args: any[]) => Generator<T, TReturn, TNext> | AsyncGenerator<T, TReturn, TNext> {
+  return ['GeneratorFunction', 'AsyncGeneratorFunction'].includes(fn.constructor.name)
+}
+
 export async function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }


### PR DESCRIPTION
支持将 generator 传入 action 中

由于 microsoft/TypeScript#51187, 类型推断暂时并不能很好地工作

另外有待讨论的是 `next` 中传入一个 `Promise<string[]>`。相关 issue microsoft/TypeScript#44808

由于 arrow generator 还在 stage 1, 这个用法可能还不够优雅