### PR TITLE
feat(core): support abbreviated subcommand alias

### DIFF
--- a/packages/core/src/command/command.ts
+++ b/packages/core/src/command/command.ts
@@ -91,7 +91,7 @@ export class Command<U extends User.Field = never, G extends Channel.Field = nev
 
   private _registerAlias(name: string, prepend = false) {
     name = name.toLowerCase()
-    if (name.startsWith('.')) name = this.parent.name + name
+    if (name.startsWith('.') && this.parent) name = this.parent.name + name
 
     // add to list
     const done = this._aliases.includes(name)

--- a/packages/core/src/command/command.ts
+++ b/packages/core/src/command/command.ts
@@ -91,6 +91,11 @@ export class Command<U extends User.Field = never, G extends Channel.Field = nev
 
   private _registerAlias(name: string, prepend = false) {
     name = name.toLowerCase()
+    name = name.split('.').reduce((previousValue, currentValue) => {
+      currentValue = (previousValue && previousValue + '.') + currentValue
+      const fullName = this.ctx.$commander.getCommand(currentValue)?.name
+      return fullName || currentValue
+    }, '')
 
     // add to list
     const done = this._aliases.includes(name)

--- a/packages/core/src/command/command.ts
+++ b/packages/core/src/command/command.ts
@@ -91,7 +91,7 @@ export class Command<U extends User.Field = never, G extends Channel.Field = nev
 
   private _registerAlias(name: string, prepend = false) {
     name = name.toLowerCase()
-    if (name.startsWith('.')) name = this.name + name
+    if (name.startsWith('.')) name = this.parent.name + name
 
     // add to list
     const done = this._aliases.includes(name)

--- a/packages/core/src/command/command.ts
+++ b/packages/core/src/command/command.ts
@@ -91,7 +91,7 @@ export class Command<U extends User.Field = never, G extends Channel.Field = nev
 
   private _registerAlias(name: string, prepend = false) {
     name = name.toLowerCase()
-    if (name.startsWith('.') && this.parent) name = this.parent.name + name
+    if (name.startsWith('.')) name = this.parent.name + name
 
     // add to list
     const done = this._aliases.includes(name)

--- a/packages/core/src/command/command.ts
+++ b/packages/core/src/command/command.ts
@@ -91,11 +91,7 @@ export class Command<U extends User.Field = never, G extends Channel.Field = nev
 
   private _registerAlias(name: string, prepend = false) {
     name = name.toLowerCase()
-    name = name.split('.').reduce((previousValue, currentValue) => {
-      currentValue = (previousValue && previousValue + '.') + currentValue
-      const fullName = this.ctx.$commander.getCommand(currentValue)?.name
-      return fullName || currentValue
-    }, '')
+    if (name.startsWith('.')) name = this.name + name
 
     // add to list
     const done = this._aliases.includes(name)


### PR DESCRIPTION
support abbreviated subcommand alias.

e.g.:
```ts
ctx.command('foo').alias('f')
ctx.command('foo.bar').alias('.b')
```
able to trigger by `foo.bar` `foo.b` `f.bar` and `f.b` .