### PR TITLE
feat(hmr): add syntax output for build errors

### DIFF
--- a/plugins/hmr/package.json
+++ b/plugins/hmr/package.json
@@ -48,7 +48,9 @@
     "koishi": "^4.12.7"
   },
   "dependencies": {
+    "@babel/code-frame": "^7.21.4",
     "chokidar": "^3.5.3",
     "throttle-debounce": "^3.0.1"
+    
   }
 }

--- a/plugins/hmr/package.json
+++ b/plugins/hmr/package.json
@@ -53,6 +53,5 @@
     "@babel/code-frame": "^7.21.4",
     "chokidar": "^3.5.3",
     "throttle-debounce": "^3.0.1"
-    
   }
 }

--- a/plugins/hmr/package.json
+++ b/plugins/hmr/package.json
@@ -44,7 +44,9 @@
     "koishi": "^4.12.7"
   },
   "devDependencies": {
+    "@types/babel__code-frame": "^7.0.3",
     "@types/throttle-debounce": "^2.1.0",
+    "esbuild": "^0.17.18",
     "koishi": "^4.12.7"
   },
   "dependencies": {

--- a/plugins/hmr/src/error.ts
+++ b/plugins/hmr/src/error.ts
@@ -1,0 +1,37 @@
+import { Logger } from 'koishi'
+import { BuildFailure } from 'esbuild'
+import { codeFrameColumns } from '@babel/code-frame'
+import { readFileSync } from 'fs'
+
+const logger = new Logger('watch')
+
+function isBuildFailure(e: any): e is BuildFailure {
+  return Array.isArray(e?.errors) && e.errors.every((error: any) => error.text)
+}
+
+export function handleError(e: any) {
+  if (!isBuildFailure(e)) {
+    logger.warn(e)
+    return
+  }
+
+  for (const error of e.errors) {
+    if (!error.location) {
+      logger.warn(error.text)
+      continue
+    }
+    try {
+      const { file, line, column } = error.location
+      const source = readFileSync(file, 'utf8')
+      const formatted = codeFrameColumns(source, {
+        start: { line, column },
+      }, {
+        highlightCode: true,
+        message: error.text,
+      })
+      logger.warn(`File: ${file}:${line}:${column}\n` + formatted)
+    } catch (e) {
+      logger.warn(e)
+    }
+  }
+}

--- a/plugins/hmr/src/index.ts
+++ b/plugins/hmr/src/index.ts
@@ -3,7 +3,8 @@ import { FSWatcher, watch, WatchOptions } from 'chokidar'
 import { relative, resolve } from 'path'
 import { debounce } from 'throttle-debounce'
 import { Loader, unwrapExports } from '@koishijs/loader'
-
+import { codeFrameColumns } from '@babel/code-frame'
+import fs from 'fs/promises'
 declare module 'koishi' {
   interface Context {
     watcher: Watcher
@@ -14,6 +15,18 @@ declare module 'koishi' {
       watch?: Watcher.Config
     }
   }
+}
+
+async function readLinesFromFile(filePath: string, startLine: number, endLine: number): Promise<string[]> {
+  const fileContent = (await fs.readFile(filePath, 'utf-8')).toString()
+  const lines = fileContent.split('\n')
+  const result = []
+
+  for (let i = startLine; i <= endLine && i < lines.length; i++) {
+    result.push(lines[i])
+  }
+
+  return result
 }
 
 function loadDependencies(filename: string, ignored: Set<string>) {
@@ -30,6 +43,23 @@ function loadDependencies(filename: string, ignored: Set<string>) {
 interface Reload {
   filename: string
   children: Map<ForkScope, string>
+}
+
+type ComplieError = {
+  detail: string | undefined
+  id: string
+  location: {
+    column: number
+    file: string
+    length: number
+    line: number
+    lineText: string
+    namespace: string
+    suggestion: string
+  }
+  notes: any[]
+  pluginName: string
+  text: string
 }
 
 const logger = new Logger('watch')
@@ -260,7 +290,24 @@ class Watcher {
         attempts[filename] = unwrapExports(require(filename))
       }
     } catch (err) {
-      logger.warn(err)
+      // logger.warn(err)
+      const error = err.errors[0] as ComplieError
+      logger.warn('Encountered compilation error while attempting to reload module:')
+      logger.warn('')
+      logger.warn(`File: ${error.location.file}:${error.location.line}:${error.location.column}`)
+      // logger.warn(`${error.text}`)
+      readLinesFromFile(error.location.file, error.location.line - 2, error.location.line + 2).then((result) => {
+        const errTip: string[] = codeFrameColumns(result.join('\n'), {
+          start: { line: 2, column: error.location.column },
+        }, {
+          highlightCode: true,
+          message: error.text,
+        }).split('\n')
+        // console.log(errTip);
+        errTip.map(line => {
+          logger.warn(line)
+        })
+      })
       return rollback()
     }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/94176676/235674309-9e9cda54-f4a2-4cc0-bc19-0fbf1f207b6b.png)

I think `console.log` is better then `logger.warn` at from L297 to L309. But in order to follow the logger standard, `logger.warn` is used.