### PR TITLE
fix(inspect): undefined property

### DIFF
--- a/plugins/common/inspect/src/index.ts
+++ b/plugins/common/inspect/src/index.ts
@@ -17,7 +17,8 @@ export function apply(ctx: Context) {
           platform: session.platform,
           guildId: session.guildId,
           selfId: session.selfId,
-          ...session.quote,
+          userId: session.quote.user.id,
+          channelId: session.quote.channel.id,
         })
       }
 

--- a/plugins/common/inspect/src/index.ts
+++ b/plugins/common/inspect/src/index.ts
@@ -17,8 +17,8 @@ export function apply(ctx: Context) {
           platform: session.platform,
           guildId: session.guildId,
           selfId: session.selfId,
-          userId: session.quote.user.id,
-          channelId: session.quote.channel.id,
+          userId: session.quote.user?.id,
+          channelId: session.quote.channel?.id,
         })
       }
 


### PR DESCRIPTION
session.quote 不存在 userId 和 channelId 两个属性

附样例

```yml
{ messageId: '-47795126', id: '-47795126', elements: [ Element { type: 'text', attrs: { content: '.inspect' }, children: [] } ], content: '.inspect', user: { id: '3767615641', name: 'narcissus', userId: '3767615641', avatar: 'http://q.qlogo.cn/headimg_dl?dst_uin=3767615641&spec=640', username: 'narcissus' }, member: { user: { id: '3767615641', name: 'narcissus', userId: '3767615641', avatar: 'http://q.qlogo.cn/headimg_dl?dst_uin=3767615641&spec=640', username: 'narcissus' }, nick: undefined, roles: [ undefined ] }, timestamp: 1709286217000, guild: { id: '292088282' }, channel: { id: '292088282', type: 0 } }
```