### PR TITLE
fix(core): default value fallback location

### DIFF
--- a/packages/core/src/command/parser.ts
+++ b/packages/core/src/command/parser.ts
@@ -463,13 +463,6 @@ export namespace Argv {
         }
       }
 
-      // assign default values
-      for (const { name, fallback } of Object.values(this._options)) {
-        if (fallback !== undefined && !(name in options)) {
-          options[name] = fallback
-        }
-      }
-
       delete argv.tokens
       return { ...argv, options, args, error: argv.error || '', command: this as any }
     }

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -377,6 +377,13 @@ export class Session<U extends User.Field = never, G extends Channel.Field = nev
     const { command } = argv
     if (!command.ctx.filter(this)) return ''
 
+    // assign default values
+    for (const { name, fallback } of Object.values(command._options)) {
+      if (fallback !== undefined && !(name in argv.options)) {
+        argv.options[name] = fallback
+      }
+    }
+
     if (this.app.database) {
       if (!this.isDirect) {
         await this.observeChannel(this.collect('channel', argv, new Set(['permissions', 'locales'])))


### PR DESCRIPTION
some command that goes interaction/command (e.g., Discord) won't pass the function contains that logic.