### PR TITLE
fix(core): should not suggest when minSimularity set to 1

### DIFF
--- a/packages/core/src/command/index.ts
+++ b/packages/core/src/command/index.ts
@@ -110,7 +110,7 @@ export class Commander {
       // use `!prefix` instead of `prefix === null` to prevent from blocking other middlewares
       // we need to make sure that the user truly has the intension to call a command
       const { argv, quote, isDirect, stripped: { prefix, appel } } = session
-      if (argv?.command || !isDirect && !prefix && !appel) return next()
+      if (argv?.command || !isDirect && !prefix && !appel || ctx.root.config.minSimilarity === 1) return next()
       const content = session.stripped.content.slice((prefix ?? '').length)
       const actual = content.split(/\s/, 1)[0].toLowerCase()
       if (!actual) return next()


### PR DESCRIPTION
当前缀非空、启用严格前缀模式、模糊系数为1时，在私聊\指向性场景使用无前缀指令仍然会触发suggest