### PR TITLE
fix(loader): resolve 'Class extends value #<Object> is not a constructor or null' error

### DIFF
--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -2,7 +2,7 @@ import { Dict, Logger } from '@koishijs/core'
 import { promises as fs } from 'fs'
 import * as dotenv from 'dotenv'
 import ns from 'ns-require'
-import Loader from './shared'
+import { Loader } from './shared'
 import { createRequire } from 'module'
 
 export * from './shared'


### PR DESCRIPTION
- Change import from 'import Loader from './shared'' to 'import { Loader } from './shared''
- Fixes ESM/CJS module interop issue causing class inheritance failure
- Resolves runtime error in Node.js ESM environments